### PR TITLE
feat(labels): relax label validation [ID-915]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Scheme, typing, encoding, decoding, and conversion packages for Kubernetes and Kubernetes-like API objects.
 
+> This fork is intended for reuse of Kubernetes logic, with slight modification, for Indent features modeled on Kubernetes. Changes include:
+>
+> + Less restrictive validation for label keys/values.
+
 
 ## Purpose
 

--- a/pkg/apis/meta/v1/validation/validation.go
+++ b/pkg/apis/meta/v1/validation/validation.go
@@ -61,7 +61,7 @@ func ValidateLabelSelectorRequirement(sr metav1.LabelSelectorRequirement, fldPat
 // ValidateLabelName validates that the label name is correctly defined.
 func ValidateLabelName(labelName string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	for _, msg := range validation.IsQualifiedName(labelName) {
+	for _, msg := range validation.IsIndentLabelName(labelName) {
 		allErrs = append(allErrs, field.Invalid(fldPath, labelName, msg))
 	}
 	return allErrs

--- a/pkg/apis/meta/v1/validation/validation_test.go
+++ b/pkg/apis/meta/v1/validation/validation_test.go
@@ -328,7 +328,7 @@ func TestValidateConditions(t *testing.T) {
 		{
 			name: "bunch-of-invalid-fields",
 			conditions: []metav1.Condition{{
-				Type:               ":invalid",
+				Type:               "\\invalid",
 				Status:             "unknown",
 				ObservedGeneration: -1,
 				LastTransitionTime: metav1.Time{},
@@ -336,7 +336,7 @@ func TestValidateConditions(t *testing.T) {
 				Message:            "",
 			}},
 			validateErrs: func(t *testing.T, errs field.ErrorList) {
-				needle := `status.conditions[0].type: Invalid value: ":invalid": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`
+				needle := `status.conditions[0].type: Invalid value: "\\invalid": name must consist of alphanumeric characters and '-', '_', '.', '/', or '@' (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '[0-9A-Za-z\/\@_\-\.]*')`
 				if !hasError(errs, needle) {
 					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
 				}

--- a/pkg/apis/meta/v1/validation/validation_test.go
+++ b/pkg/apis/meta/v1/validation/validation_test.go
@@ -42,6 +42,8 @@ func TestValidateLabels(t *testing.T) {
 		{"1.2.3.4/5678": "bar"},
 		{"UpperCaseAreOK123": "bar"},
 		{"goodvalue": "123_-.BaR"},
+		{"cantendwithadash-": "bar"},
+		{"only/one/slash": "bar"},
 	}
 	for i := range successCases {
 		errs := ValidateLabels(successCases[i], field.NewPath("field"))
@@ -50,8 +52,7 @@ func TestValidateLabels(t *testing.T) {
 		}
 	}
 
-	namePartErrMsg := "name part must consist of"
-	nameErrMsg := "a qualified name must consist of"
+	namePartErrMsg := "name must consist of"
 	labelErrMsg := "a valid label must be an empty string or consist of"
 	maxLengthErrMsg := "must be no more than"
 
@@ -60,8 +61,6 @@ func TestValidateLabels(t *testing.T) {
 		expect string
 	}{
 		{map[string]string{"nospecialchars^=@": "bar"}, namePartErrMsg},
-		{map[string]string{"cantendwithadash-": "bar"}, namePartErrMsg},
-		{map[string]string{"only/one/slash": "bar"}, nameErrMsg},
 		{map[string]string{strings.Repeat("a", 254): "bar"}, maxLengthErrMsg},
 	}
 	for i := range labelNameErrorCases {

--- a/pkg/util/validation/indent.go
+++ b/pkg/util/validation/indent.go
@@ -1,18 +1,28 @@
 package validation
 
-// IsIndentLabelName tests whether the value passed is an Indent-acceptable
+const (
+	labelNameFmt           = labelValueFmt
+	labelNameErrMsg string = "must consist of alphanumeric characters and '-', '_', '.', '/', or '@'"
+)
+
+var labelNameRegexp = labelValueRegexp
+
+// IsIndentLabelName tests whether the name passed is an Indent-acceptable
 // label name (key). If the value is not valid, a list of error strings is
 // returned. Otherwise an empty list (or nil) is returned.
 //
 // See IsQualifiedName; this is an Indent labels-specific drop-in replacement
 // for that function. IsQualifiedName is used for apimachinery purposes besides
 // labels, so it should not be modified.
-func IsIndentLabelName(value string) []string {
+func IsIndentLabelName(name string) []string {
 	var errs []string
-	if len(value) == 0 {
+	if len(name) == 0 {
 		errs = append(errs, "name "+EmptyError())
-	} else if len(value) > qualifiedNameMaxLength {
+	} else if len(name) > qualifiedNameMaxLength {
 		errs = append(errs, "name "+MaxLenError(qualifiedNameMaxLength))
+	}
+	if !labelNameRegexp.MatchString(name) {
+		errs = append(errs, "name "+RegexError(labelNameErrMsg, labelNameFmt, "MyName", "my.name", "123-abc"))
 	}
 	return errs
 }

--- a/pkg/util/validation/indent.go
+++ b/pkg/util/validation/indent.go
@@ -1,0 +1,18 @@
+package validation
+
+// IsIndentLabelName tests whether the value passed is an Indent-acceptable
+// label name (key). If the value is not valid, a list of error strings is
+// returned. Otherwise an empty list (or nil) is returned.
+//
+// See IsQualifiedName; this is an Indent labels-specific drop-in replacement
+// for that function. IsQualifiedName is used for apimachinery purposes besides
+// labels, so it should not be modified.
+func IsIndentLabelName(value string) []string {
+	var errs []string
+	if len(value) == 0 {
+		errs = append(errs, "name "+EmptyError())
+	} else if len(value) > qualifiedNameMaxLength {
+		errs = append(errs, "name "+MaxLenError(qualifiedNameMaxLength))
+	}
+	return errs
+}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -27,13 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-const qnameCharFmt string = "[A-Za-z0-9]"
-const qnameExtCharFmt string = "[-A-Za-z0-9_.]"
-const qualifiedNameFmt string = "(" + qnameCharFmt + qnameExtCharFmt + "*)?" + qnameCharFmt
-const qualifiedNameErrMsg string = "must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
 const qualifiedNameMaxLength int = 63
-
-var qualifiedNameRegexp = regexp.MustCompile("^" + qualifiedNameFmt + "$")
 
 // IsQualifiedName tests whether the value passed is what Kubernetes calls a
 // "qualified name".  This is a format used in various places throughout the
@@ -41,31 +35,10 @@ var qualifiedNameRegexp = regexp.MustCompile("^" + qualifiedNameFmt + "$")
 // Otherwise an empty list (or nil) is returned.
 func IsQualifiedName(value string) []string {
 	var errs []string
-	parts := strings.Split(value, "/")
-	var name string
-	switch len(parts) {
-	case 1:
-		name = parts[0]
-	case 2:
-		var prefix string
-		prefix, name = parts[0], parts[1]
-		if len(prefix) == 0 {
-			errs = append(errs, "prefix part "+EmptyError())
-		} else if msgs := IsDNS1123Subdomain(prefix); len(msgs) != 0 {
-			errs = append(errs, prefixEach(msgs, "prefix part ")...)
-		}
-	default:
-		return append(errs, "a qualified name "+RegexError(qualifiedNameErrMsg, qualifiedNameFmt, "MyName", "my.name", "123-abc")+
-			" with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')")
-	}
-
-	if len(name) == 0 {
+	if len(value) == 0 {
 		errs = append(errs, "name part "+EmptyError())
-	} else if len(name) > qualifiedNameMaxLength {
+	} else if len(value) > qualifiedNameMaxLength {
 		errs = append(errs, "name part "+MaxLenError(qualifiedNameMaxLength))
-	}
-	if !qualifiedNameRegexp.MatchString(name) {
-		errs = append(errs, "name part "+RegexError(qualifiedNameErrMsg, qualifiedNameFmt, "MyName", "my.name", "123-abc"))
 	}
 	return errs
 }
@@ -152,13 +125,8 @@ func IsDomainPrefixedPath(fldPath *field.Path, dpPath string) field.ErrorList {
 	return allErrs
 }
 
-const labelValueFmt string = "(" + qualifiedNameFmt + ")?"
-const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
-
 // LabelValueMaxLength is a label's max length
 const LabelValueMaxLength int = 63
-
-var labelValueRegexp = regexp.MustCompile("^" + labelValueFmt + "$")
 
 // IsValidLabelValue tests whether the value passed is a valid label value.  If
 // the value is not valid, a list of error strings is returned.  Otherwise an
@@ -167,9 +135,6 @@ func IsValidLabelValue(value string) []string {
 	var errs []string
 	if len(value) > LabelValueMaxLength {
 		errs = append(errs, MaxLenError(LabelValueMaxLength))
-	}
-	if !labelValueRegexp.MatchString(value) {
-		errs = append(errs, RegexError(labelValueErrMsg, labelValueFmt, "MyValue", "my_value", "12345"))
 	}
 	return errs
 }

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -152,8 +152,13 @@ func IsDomainPrefixedPath(fldPath *field.Path, dpPath string) field.ErrorList {
 	return allErrs
 }
 
+const labelValueFmt string = `[0-9A-Za-z\/\@_\-\.]*`
+const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
+
 // LabelValueMaxLength is a label's max length
 const LabelValueMaxLength int = 63
+
+var labelValueRegexp = regexp.MustCompile("^" + labelValueFmt + "$")
 
 // IsValidLabelValue tests whether the value passed is a valid label value.  If
 // the value is not valid, a list of error strings is returned.  Otherwise an
@@ -162,6 +167,9 @@ func IsValidLabelValue(value string) []string {
 	var errs []string
 	if len(value) > LabelValueMaxLength {
 		errs = append(errs, MaxLenError(LabelValueMaxLength))
+	}
+	if !labelValueRegexp.MatchString(value) {
+		errs = append(errs, RegexError(labelValueErrMsg, labelValueFmt, "MyValue", "my_value", "12345"))
 	}
 	return errs
 }

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -298,6 +298,12 @@ func TestIsValidLabelValue(t *testing.T) {
 		"1234",                  // only num
 		strings.Repeat("a", 63), // to the limit
 		"",                      // empty value
+		"-starts-with-dash",
+		"ends-with-dash-",
+		".starts.with.dot",
+		"ends.with.dot.",
+		"email@email.com",
+		"indent.com/namespaced/identifier",
 	}
 	for i := range successCases {
 		if errs := IsValidLabelValue(successCases[i]); len(errs) != 0 {
@@ -306,18 +312,14 @@ func TestIsValidLabelValue(t *testing.T) {
 	}
 
 	errorCases := []string{
-		"nospecialchars%^=@",
+		"specialchars%^=@",
 		"Tama-nui-te-rā.is.Māori.sun",
 		"\\backslashes\\are\\bad",
-		"-starts-with-dash",
-		"ends-with-dash-",
-		".starts.with.dot",
-		"ends.with.dot.",
 		strings.Repeat("a", 64), // over the limit
 	}
-	for i := range errorCases {
+	for i, c := range errorCases {
 		if errs := IsValidLabelValue(errorCases[i]); len(errs) == 0 {
-			t.Errorf("case[%d] expected failure", i)
+			t.Errorf("case[%d] (%v) expected failure", i, c)
 		}
 	}
 }


### PR DESCRIPTION
## Description

Relaxes several Kubernetes restrictions on label keys/values to support existing Indent label patterns.

+ Allows multiple forward-slashes in both names and values.
+ Removes exclusion of certain leading and trailing characters.
+ Allows the character `@` in both names and values.

Repo housekeeping: adds a README disclaimer, our standard PR template.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Fixes

- ID-915

## Checklists

- [x] Pull request has a descriptive title and summary.
- [x] Pull request has been linked to Jira.
- [x] Pull request has reviewers assigned.
