### PR TITLE
feat(labels): use IsIndentLabelName in lieu of IsQualifiedName [ID-915]

### DIFF
--- a/pkg/apis/meta/v1/validation/validation_test.go
+++ b/pkg/apis/meta/v1/validation/validation_test.go
@@ -336,7 +336,7 @@ func TestValidateConditions(t *testing.T) {
 				Message:            "",
 			}},
 			validateErrs: func(t *testing.T, errs field.ErrorList) {
-				needle := `status.conditions[0].type: Invalid value: "\\invalid": name must consist of alphanumeric characters and '-', '_', '.', '/', or '@' (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '[0-9A-Za-z\/\@_\-\.]*')`
+				needle := `status.conditions[0].type: Invalid value: "\\invalid": name must consist of alphanumeric characters and '-', '_', '.', '/', or '@' (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '[0-9A-Za-z\/\@_\-\.\+]*')`
 				if !hasError(errs, needle) {
 					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
 				}

--- a/pkg/labels/selector.go
+++ b/pkg/labels/selector.go
@@ -889,7 +889,7 @@ func parse(selector string, path *field.Path) (internalSelector, error) {
 }
 
 func validateLabelKey(k string, path *field.Path) *field.Error {
-	if errs := validation.IsQualifiedName(k); len(errs) != 0 {
+	if errs := validation.IsIndentLabelName(k); len(errs) != 0 {
 		return field.Invalid(path, k, strings.Join(errs, "; "))
 	}
 	return nil

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -47,6 +47,7 @@ func TestSelectorParse(t *testing.T) {
 		"x>1,z<5",
 		"indent.com/some/label=indent.com/some/value",
 		"indent.com/some/label=some@email.com",
+		"indent.com/resource/email in (abc+def@email.com, some@email.com)",
 	}
 	testBadStrings := []string{
 		"x=a||y=b",

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -47,7 +47,6 @@ func TestSelectorParse(t *testing.T) {
 		"x>1,z<5",
 		"indent.com/some/label=indent.com/some/value",
 		"indent.com/some/label=some@email.com",
-		"indent.com/resource/email in (abc+def@email.com, some@email.com)",
 	}
 	testBadStrings := []string{
 		"x=a||y=b",

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -45,6 +45,8 @@ func TestSelectorParse(t *testing.T) {
 		"!x",
 		"x>1",
 		"x>1,z<5",
+		"indent.com/some/label=indent.com/some/value",
+		"indent.com/some/label=some@email.com",
 	}
 	testBadStrings := []string{
 		"x=a||y=b",

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -152,7 +152,7 @@ func IsDomainPrefixedPath(fldPath *field.Path, dpPath string) field.ErrorList {
 	return allErrs
 }
 
-const labelValueFmt string = `[0-9A-Za-z\/\@_\-\.]*`
+const labelValueFmt string = `[0-9A-Za-z\/\@_\-\.\+]*`
 const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
 
 // LabelValueMaxLength is a label's max length

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -303,6 +303,7 @@ func TestIsValidLabelValue(t *testing.T) {
 		".starts.with.dot",
 		"ends.with.dot.",
 		"email@email.com",
+		"email+ext@email.com",
 		"indent.com/namespaced/identifier",
 	}
 	for i := range successCases {


### PR DESCRIPTION
## Description

A change missing from #1: use the new validation function in lieu of `isQualifiedName` when validating label names.

Adds Indent-ish cases to the `Parse` integration test.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Fixes

- ID-915

## Checklists

- [x] Pull request has a descriptive title and summary.
- [x] Pull request has been linked to Jira.
- [x] Pull request has reviewers assigned.
