### PR TITLE
feat(labels): allow colons in label selectors [ID-915]

### DIFF
--- a/pkg/apis/meta/v1/validation/validation_test.go
+++ b/pkg/apis/meta/v1/validation/validation_test.go
@@ -336,7 +336,7 @@ func TestValidateConditions(t *testing.T) {
 				Message:            "",
 			}},
 			validateErrs: func(t *testing.T, errs field.ErrorList) {
-				needle := `status.conditions[0].type: Invalid value: "\\invalid": name must consist of alphanumeric characters and '-', '_', '.', '/', or '@' (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '[0-9A-Za-z\/\@_\-\.\+]*')`
+				needle := `status.conditions[0].type: Invalid value: "\\invalid": name must consist of alphanumeric characters and '-', '_', '.', '/', or '@' (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '[0-9A-Za-z\/\@_\-\.\+:]*')`
 				if !hasError(errs, needle) {
 					t.Errorf("missing %q in\n%v", needle, errorsAsString(errs))
 				}

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -152,7 +152,7 @@ func IsDomainPrefixedPath(fldPath *field.Path, dpPath string) field.ErrorList {
 	return allErrs
 }
 
-const labelValueFmt string = `[0-9A-Za-z\/\@_\-\.\+]*`
+const labelValueFmt string = `[0-9A-Za-z\/\@_\-\.\+:]*`
 const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
 
 // LabelValueMaxLength is a label's max length


### PR DESCRIPTION
## Description

Allows colons in label selectors, e.g. `"indent.com/some:kind"`.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Fixes

- Relates to ID-915

## Checklists

- [x] Pull request has a descriptive title and summary.
- [x] Pull request has been linked to Jira.
- [x] Pull request has reviewers assigned.
