### PR TITLE
feat(labels): allow 128-character label values [ID-1318]

### DIFF
--- a/pkg/apis/meta/v1/validation/validation_test.go
+++ b/pkg/apis/meta/v1/validation/validation_test.go
@@ -78,7 +78,7 @@ func TestValidateLabels(t *testing.T) {
 		labels map[string]string
 		expect string
 	}{
-		{map[string]string{"toolongvalue": strings.Repeat("a", 64)}, maxLengthErrMsg},
+		{map[string]string{"toolongvalue": strings.Repeat("a", 129)}, maxLengthErrMsg},
 		{map[string]string{"backslashesinvalue": "some\\bad\\value"}, labelErrMsg},
 		{map[string]string{"nocommasallowed": "bad,value"}, labelErrMsg},
 		{map[string]string{"strangecharsinvalue": "?#$notsogood"}, labelErrMsg},

--- a/pkg/labels/selector_test.go
+++ b/pkg/labels/selector_test.go
@@ -917,12 +917,12 @@ func TestValidatedSelectorFromSet(t *testing.T) {
 		},
 		{
 			name:  "Invalid Set, value too long",
-			input: Set{"Key": "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui"},
+			input: Set{"Key": "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nuiaxahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nuia"},
 			expectedError: field.ErrorList{
 				&field.Error{
 					Type:     field.ErrorTypeInvalid,
 					Field:    "values[0][Key]",
-					BadValue: "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui",
+					BadValue: "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nuiaxahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nuia",
 				},
 			},
 		},

--- a/pkg/util/validation/validation.go
+++ b/pkg/util/validation/validation.go
@@ -157,7 +157,7 @@ const labelValueFmt string = `[0-9A-Za-z\/\@_\-\.\+:]*`
 const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
 
 // LabelValueMaxLength is a label's max length
-const LabelValueMaxLength int = 63
+const LabelValueMaxLength int = 128
 
 var labelValueRegexp = regexp.MustCompile("^" + labelValueFmt + "$")
 

--- a/pkg/util/validation/validation_test.go
+++ b/pkg/util/validation/validation_test.go
@@ -295,9 +295,9 @@ func TestIsValidLabelValue(t *testing.T) {
 		"now-with-dashes",
 		"1-starts-with-num",
 		"end-with-num-1",
-		"1234",                  // only num
-		strings.Repeat("a", 63), // to the limit
-		"",                      // empty value
+		"1234",                   // only num
+		strings.Repeat("a", 128), // to the limit
+		"",                       // empty value
 		"-starts-with-dash",
 		"ends-with-dash-",
 		".starts.with.dot",
@@ -316,7 +316,7 @@ func TestIsValidLabelValue(t *testing.T) {
 		"specialchars%^=@",
 		"Tama-nui-te-rā.is.Māori.sun",
 		"\\backslashes\\are\\bad",
-		strings.Repeat("a", 64), // over the limit
+		strings.Repeat("a", 129), // over the limit
 	}
 	for i, c := range errorCases {
 		if errs := IsValidLabelValue(errorCases[i]); len(errs) == 0 {


### PR DESCRIPTION
## Description

Consider 128-character label values valid.

Once this is released:

+ Merge upstream changes (the latest k8s.io minor version).
+ Tag a release in this repo.
+ Update indentinc/indent to pin the new tag.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Fixes

- ID-1318

## Checklists

- [x] Pull request has a descriptive title and summary.
- [x] Pull request has been linked to Jira.
- [x] Pull request has reviewers assigned.
